### PR TITLE
Log download statistics and errors on "downloads.log"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
 	"dependencies": {
 		"async": "0.1.22",
 		"connect": "1.8.5",
+		"dateformat": "1.0.2-1.2.3",
 		"formidable": "1.0.9",
+		"glob-whatev": "0.1.7",
 		"handlebars": "latest",
 		"rimraf": "2.0.1",
-		"glob-whatev": "0.1.7",
-		"dateformat": "1.0.2-1.2.3",
-		"underscore": "~1.3.3"
+		"underscore": "~1.3.3",
+		"winston": "latest" 
 	},
 	"engine": {
 		"node": ">=0.8.x"


### PR DESCRIPTION
1st Draft. Follow an example of the download-statistic-log output:

```
 2012-07-20T14:29:56.852Z - info: {"components":["widget","core","mouse","position","draggable","droppable","resizable","selectable","sortable","accordion","autocomplete","button","datepicker","dialog","menu","progressbar","slider","spinner","tabs","tooltip","effect","effect-blind","effect-bounce","effect-clip","effect-drop","effect-explode","effect-fade","effect-fold","effect-highlight","effect-pulsat
 e","effect-scale","effect-shake","effect-slide","effect-transfer"],"build_time":978}
```

Dependecy added:
- [winston](https://github.com/flatiron/winston#using-custom-logging-levels): logging lib;

Questions:

1) Shall we use a separate file for statistics (downloads.log) vs. errors (download_errors?.log)?
2) JSON or key-value pairs in the log output? [Splunk](http://dev.splunk.com/view/SP-CAAADP6) doc tells both are ok, as far as I understood;
3)

> Log each download with the following data: Selected components, selected theme (or "custom"), time to generate zip, time to handle request

I'm logging selected components, and time to generate zip.

3.a) The time to handle request is logged via connect.logger. Should we log it as well in download stats as well? Why?
3.b) The selected theme (or "custom"): we have not implemented theme selection so far... Shall we add it later or assume a variable name for it?
