### PR TITLE
Replace zip utility with zipstream (files cached in memory, no disk IO on package build)

### DIFF
--- a/build-backend.js
+++ b/build-backend.js
@@ -8,12 +8,19 @@ var async = require( "async" ),
 	handlebars = require( "handlebars" ),
 	rimraf = require( "rimraf" ),
 	spawn = require( "child_process" ).spawn,
-	winston = require( "winston" );
+	winston = require( "winston" ),
+	zipstream = require( "zipstream" );
 
 var input = glob( "versions/*" )[0];
 
 var indexTemplate = handlebars.compile( fs.readFileSync( "zip-index.html", "utf8" ) ),
-	pkg = JSON.parse( fs.readFileSync( input + "/package.json" ) );
+	pkg = JSON.parse( fs.readFileSync( input + "/package.json" ) ),
+	cache = {},
+	commonFiles = [],
+	componentFiles = [],
+	demoFiles = [],
+	imageFiles = {},
+	jqueryFilename;
 
 var download_logger = new winston.Logger({
 		transports: [
@@ -25,169 +32,216 @@ var download_logger = new winston.Logger({
 	});
 
 function stripBanner( src ) {
+	if ( src instanceof Buffer ) {
+		src = src.toString( "utf-8" );
+	}
 	return src.replace( /^\s*\/\*[\s\S]*?\*\/\s*/g, "" );
 }
 
-function Builder( fields ) {
-	this.fields = fields;
+function cacheIt( filepath ) {
+	cache[ filepath ] = fs.readFileSync( input + filepath );
 }
-Builder.prototype = {
-	// TODO make everything ASYNC
-	build: function( callback ) {
-		var tmpdir = "tmp" + (+new Date()),
-			target = "jquery-ui-" + pkg.version + ".custom",
-			targetdir = tmpdir + "/" + target + "/";
-		fs.mkdirSync( tmpdir );
-		fs.mkdirSync( targetdir );
 
-		fs.mkdirSync( targetdir + "development-bundle" );
-		glob( input + "/*.*" ).forEach(function( file ) {
-			// would be nice if we could glob to do this for us
-			if ( (/\.jquery\.json$/).test( file ) ) {
-				return;
-			}
-			fs.writeFileSync( targetdir + file.replace(input, "development-bundle/"), fs.readFileSync( file ) );
-		});
+/**
+ * Build cache
+ */
 
-		fs.mkdirSync( targetdir + "development-bundle/external" );
-		glob( input + "/external/*" ).forEach(function( file ) {
-			fs.writeFileSync( targetdir + file.replace(input, "development-bundle/"), fs.readFileSync( file ) );
-		});
-
-		fs.mkdirSync( targetdir + "development-bundle/demos" );
-		fs.writeFileSync( targetdir + "development-bundle/demos/demos.css", fs.readFileSync( input + "demos/demos.css" ) );
-		fs.mkdirSync( targetdir + "development-bundle/demos/images" );
-		glob( input + "/demos/images/*" ).forEach(function( file ) {
-			fs.writeFileSync( targetdir + file.replace(input, "development-bundle/"), fs.readFileSync( file ) );
-		});
-
-		var ui = {
-			version: pkg.version
-		};
-		fs.mkdirSync( targetdir + "development-bundle/ui" );
-		fs.mkdirSync( targetdir + "development-bundle/ui/minified" );
-
-		fs.mkdirSync( targetdir + "development-bundle/themes" );
-		fs.mkdirSync( targetdir + "development-bundle/themes/base" );
-		fs.mkdirSync( targetdir + "development-bundle/themes/base/images" );
-		fs.mkdirSync( targetdir + "development-bundle/themes/base/minified" );
-		fs.mkdirSync( targetdir + "development-bundle/themes/base/minified/images" );
-		glob( input + "themes/base/images/*" ).forEach(function( file ) {
-			fs.writeFileSync( targetdir + file.replace(input, "development-bundle/"), fs.readFileSync( file ) );
-			fs.writeFileSync( targetdir + file.replace(input + "themes/base/", "development-bundle/themes/base/minified/"), fs.readFileSync( file ) );
-		});
-
-		var header = banner( pkg, this.fields.map(function( field ) {
-			return "jquery.ui." + field + ".js";
-		}) ) + "\n";
-		var concatFiles = header,
-			minifiedFiles = header,
-			cssFields = [],
-			cssConcatFiles = "",
-			cssMinifiedFiles = "";
-		this.fields.forEach(function( field ) {
-			ui[ field ] = true;
-
-			var file = "ui/jquery.ui." + field + ".js";
-			var content = fs.readFileSync( input + file, "utf-8" );
-			concatFiles += stripBanner( content );
-			fs.writeFileSync( targetdir + "development-bundle/" + file, content );
-
-			var minfile = "ui/minified/jquery.ui." + field + ".min.js";
-			var minifiedContent = fs.readFileSync( input + minfile, "utf-8" );
-			fs.writeFileSync( targetdir + "development-bundle/" + minfile, minifiedContent );
-			minifiedFiles += stripBanner( minifiedContent );
-
-			if ( fs.existsSync( input + "demos/" + field ) ) {
-				fs.mkdirSync( targetdir + "development-bundle/demos/" + field );
-				glob( input + "demos/" + field + "/**" ).forEach(function( file ) {
-					if ( fs.statSync( file ).isDirectory() ) {
-						fs.mkdirSync( targetdir + file.replace(input, "development-bundle/") );
-					} else {
-						fs.writeFileSync( targetdir + file.replace(input, "development-bundle/"), fs.readFileSync( file ) );
-					}
-				});
-			}
-
-			var jsonFile = input + "ui." + field + ".jquery.json";
-			fs.writeFileSync( targetdir + jsonFile.replace(input, "development-bundle/"), fs.readFileSync( jsonFile ) );
-
-			var cssFile = "themes/base/jquery.ui." + field + ".css";
-			if ( fs.existsSync( input + cssFile )) {
-				cssFields.push( field );
-				var cssContent = fs.readFileSync( input + cssFile, "utf-8" );
-				cssConcatFiles += stripBanner( cssContent );
-				fs.writeFileSync( targetdir + "development-bundle/" + cssFile, cssContent );
-
-				var cssMinfile = "themes/base/minified/jquery.ui." + field + ".min.css";
-				var cssMinifiedContent = fs.readFileSync( input + cssMinfile, "utf-8" );
-				fs.writeFileSync( targetdir + "development-bundle/" + cssMinfile, cssMinifiedContent );
-				cssMinifiedFiles += stripBanner( cssMinifiedContent );
-			}
-		});
-
-		fs.writeFileSync( targetdir + "development-bundle/ui/jquery-ui-" + ui.version + ".custom.js", concatFiles );
-		fs.writeFileSync( targetdir + "development-bundle/ui/minified/jquery-ui-" + ui.version + ".custom.min.js", minifiedFiles );
-
-		var cssHeader = banner( pkg, cssFields.map(function( field ) {
-			return "jquery.ui." + field + ".css";
-		}) ) + "\n";
-		cssConcatFiles = cssHeader + cssConcatFiles;
-		cssMinifiedFiles = cssHeader + cssMinifiedFiles;
-		fs.writeFileSync( targetdir + "development-bundle/themes/base/jquery-ui-" + ui.version + ".custom.css", cssConcatFiles );
-		fs.writeFileSync( targetdir + "development-bundle/themes/base/minified/jquery-ui-" + ui.version + ".custom.min.css", cssMinifiedFiles );
-
-		fs.mkdirSync( targetdir + "js" );
-
-		var jquery;
-		glob( input + "/jquery-*.js" ).forEach(function( file ) {
-			jquery = file.replace( input, "" );
-			fs.writeFileSync( targetdir + file.replace( input, "js/" ), fs.readFileSync( file ) );
-		});
-		fs.writeFileSync( targetdir + "index.html", indexTemplate({
-			jquery: jquery,
-			ui: ui
-		}) );
-
-		fs.writeFileSync( targetdir + "js/jquery-ui-" + ui.version + ".custom.js", concatFiles );
-		fs.writeFileSync( targetdir + "js/jquery-ui-" + ui.version + ".custom.min.js", minifiedFiles );
-
-		fs.mkdirSync( targetdir + "css" );
-		fs.mkdirSync( targetdir + "css/base" );
-		fs.writeFileSync( targetdir + "css/base/jquery-ui-" + ui.version + ".custom.css", cssConcatFiles );
-		fs.writeFileSync( targetdir + "css/base/jquery-ui-" + ui.version + ".custom.min.css", cssMinifiedFiles );
-
-		fs.mkdirSync( targetdir + "css/base/images" );
-		glob( input + "themes/base/images/*" ).forEach(function( file ) {
-			fs.writeFileSync( targetdir + file.replace(input + "themes", "css"), fs.readFileSync( file ) );
-		});
-
-		callback( tmpdir, target );
+var flatten = function( flat, arr ) {
+		return flat.concat( arr );
 	},
+	noDirectory = function( filepath ) {
+		return ! fs.statSync( filepath ).isDirectory();
+	},
+	stripInput = function( filepath ) {
+		return filepath.replace( input, "" );
+	};
+
+// Common files
+commonFiles = [
+	"/*",
+	"/external/*",
+	"/demos/demos.css",
+	"/demos/images/*",
+	"/themes/base/images/*",
+	"/themes/base/minified/images/*"
+].map(function( path ) {
+	return glob( input + path ).filter( noDirectory ).map( stripInput ).filter(function( filepath ) {
+		return ! (/^MANIFEST$|\.jquery\.json$/).test( filepath );
+	});
+}).reduce( flatten, [] );
+
+// Component files
+componentFiles = [
+	"/*jquery.json",
+	"/ui/**",
+	"/themes/base/jquery*",
+	"/themes/base/minified/jquery*"
+].map(function( path ) {
+	return glob( input + path ).filter( noDirectory ).map( stripInput );
+}).reduce( flatten, [] );
+
+// Demo files
+demoFiles = glob( input + "/demos/*/**" ).filter( noDirectory ).map( stripInput );
+
+// Cache them
+commonFiles.forEach( cacheIt );
+componentFiles.forEach( cacheIt );
+demoFiles.forEach( cacheIt );
+
+// Auxiliary variables
+imageFiles = glob( input + "/themes/base/images/*" ).map( stripInput );
+jqueryFilename = stripInput( glob( input + "/jquery-*" )[ 0 ] );
+
+
+/**
+ * Builder
+ */
+function Builder( fields ) {
+	var cssHeader, existingCss, header;
+
+	this.basedir = "jquery-ui-" + pkg.version + ".custom";
+	this.fields = fields;
+	this.ui = this.fields.reduce(function( sum, field ) {
+		sum[ field ] = true;
+		return sum;
+	}, {});
+	this.ui.version = pkg.version;
+
+	header = banner( pkg, this.fields.map(function( field ) {
+		return "jquery.ui." + field + ".js";
+	}) ) + "\n";
+	this.full = this.fields.reduce(function( sum, field ) {
+		return sum + stripBanner( cache[ "ui/jquery.ui." + field + ".js" ] );
+	}, header );
+	this.min = this.fields.reduce(function( sum, field ) {
+		return sum + stripBanner( cache[ "ui/minified/jquery.ui." + field + ".min.js" ] );
+	}, header );
+
+	existingCss = function( field ) {
+		return cache[ "themes/base/jquery.ui." + field + ".css" ] !== undefined;
+	};
+	cssHeader = banner( pkg, this.fields.filter( existingCss ).map(function( field ) {
+		return "jquery.ui." + field + ".css";
+	}) ) + "\n";
+	this.cssFull = this.fields.reduce(function( sum, field ) {
+		return sum + stripBanner( cache[ "themes/base/jquery.ui." + field + ".css" ] || "" );
+	}, cssHeader );
+	this.cssMin = this.fields.reduce(function( sum, field ) {
+		return sum + stripBanner( cache[ "themes/base/minified/jquery.ui." + field + ".min.css" ] || "" );
+	}, cssHeader );
+}
+
+Builder.prototype = {
+	/**
+	 * Generates a build array [ <build-item>, ... ], where
+	 * build-item = {
+	 *   path: String:package destination filepath,
+	 *   data: String/Buffer:the content itself
+	 * }
+	 */
+	build: function( callback ) {
+		var add = function( src, dst ) {
+				build.push({
+					path: [ basedir ].concat( dst ).join( "/" ),
+					data: cache[ src ]
+				});
+			},
+			addEach = function( dst ) {
+				return function( filepath ) {
+					add( filepath, dst.concat( filepath ) );
+				};
+			},
+			basedir = this.basedir,
+			build = [],
+			cssFull = this.cssFull,
+			cssMin = this.cssMin,
+			full = this.full,
+			min = this.min,
+			selectedRe = new RegExp( this.fields.join( "|" ) ),
+			selected = function( filepath ) {
+				return selectedRe.test( filepath );
+			};
+
+		commonFiles.forEach( addEach( [ "development-bundle" ] ) );
+		componentFiles.filter( selected ).forEach( addEach( [ "development-bundle" ] ) );
+		demoFiles.filter(function( filepath ) {
+			var componentSubdir = filepath.split( "/" )[ 1 ];
+			return selected( componentSubdir );
+		}).forEach( addEach( [ "development-bundle" ] ));
+
+		// Full
+		[ "development-bundle/ui/jquery-ui-" + pkg.version + ".custom.js",
+		  "js/jquery-ui-" + pkg.version + ".custom.js"
+		].forEach(function( dst ) {
+			build.push({
+				path: [ basedir, dst ].join( "/" ),
+				data: full
+			});
+		});
+		[ "development-bundle/themes/base/jquery-ui-" + pkg.version + ".custom.css",
+		  "css/base/jquery-ui-" + pkg.version + ".custom.css"
+		].forEach(function( dst ) {
+			build.push({
+				path: [ basedir, dst ].join( "/" ),
+				data: cssFull
+			});
+		});
+
+		// Min
+		[ "development-bundle/ui/minified/jquery-ui-" + pkg.version + ".custom.min.js",
+		  "js/jquery-ui-" + pkg.version + ".custom.min.js"
+		].forEach(function( dst ) {
+			build.push({
+				path: [ basedir, dst ].join( "/" ),
+				data: min
+			});
+		});
+		[ "development-bundle/themes/base/minified/jquery-ui-" + pkg.version + ".custom.min.css",
+		  "css/base/jquery-ui-" + pkg.version + ".custom.min.css"
+		].forEach(function( dst ) {
+			build.push({
+				path: [ basedir, dst ].join( "/" ),
+				data: cssMin
+			});
+		});
+
+		// Ad hoc
+		if ( this.fields.indexOf( "datepicker" ) >= 0 ) {
+			[ "ui/i18n/jquery-ui-i18n.js", "ui/minified/i18n/jquery-ui-i18n.min.js" ].forEach( addEach( ["development-bundle"] ) );
+		}
+		imageFiles.forEach(function( filepath ) {
+			add( filepath, [ filepath.replace( "themes", "css" ) ] );
+		});
+		add( jqueryFilename, [ "js", jqueryFilename ] );
+		build.push({
+			path: [ basedir, "index.html" ].join( "/" ),
+			data: indexTemplate({
+				jquery: jqueryFilename,
+				ui: this.ui
+			})
+		});
+
+		callback( build );
+	},
+
 	writeTo: function( response, callback ) {
 		var that = this,
 			start = new Date();
-		this.build(function( cwd, target ) {
-			var child = spawn( "zip", [ "-r", "-", target ], { cwd: cwd } );
-			child.stdout.on( "data", function( data) {
-				response.write( data );
-			});
-			child.stderr.on( "data", function( data) {
-				// console.error( data.toString() );
-			});
-			child.on( "exit", function( code ) {
-				rimraf.sync( cwd );
-				if ( code !== 0 ) {
-					download_logger.error( "zip failed :(" );
-					callback( "zip failed :(" );
-					return;
-				}
-				// Log statistics
-				download_logger.info( JSON.stringify({
-					components: that.fields,
-					build_time: new Date() - start
-				}) );
-				callback( null, "All good!" );
+		this.build(function( build ) {
+			var zip = zipstream.createZip();
+			zip.pipe( response );
+			async.forEachSeries( build, function( file, next ) {
+				zip.addFile( file.data, { name: file.path }, next );
+			}, function() {
+				zip.finalize(function( written ) {
+					// Log statistics
+					download_logger.info( JSON.stringify({
+						components: that.fields,
+						build_size: written,
+						build_time: new Date() - start
+					}) );
+					callback( null, "All good!" );
+				});
 			});
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"handlebars": "latest",
 		"rimraf": "2.0.1",
 		"underscore": "~1.3.3",
-		"winston": "latest"
+		"winston": "latest",
+		"zipstream": "git://github.com/rxaviers/node-zipstream.git"
 	},
 	"main": "build-frontend.js",
 	"engine": {


### PR DESCRIPTION
- Files are cached in memory when backend is initialized;
- Package build is free of disk IO;

Speed comparison: (in my laptop)
 1) zipstream cached on memory: 0.7s
 2) zip tool: 1.1s
 3) zipstream with disk access: 1.5s

Signed off by:
- Jörn Zaefferer `<joern.zaefferer at gmail.com>`
- Rafael Xavier `<rxaviers at gmail.com>`
