### PR TITLE
Make input fileds wider to show their values in full

### DIFF
--- a/app/resources/themeroller.css
+++ b/app/resources/themeroller.css
@@ -1,4 +1,3 @@
-
 /* jqueryui.com site overrides for TR */
 #themeroller-content {
 	float: left;
@@ -381,7 +380,7 @@
 	padding: 1px;
 }
 input.opacity, input.offset {
-	width: 20px;
+	width: 25px;
 	float: left;
 }
 span.opacity-per {
@@ -389,16 +388,18 @@ span.opacity-per {
 	padding: 0 .2em;
 }
 #themeroller .application input.hex {
-	width: 42px;
+	width: 46px;
 	outline: 0;
 }
 input#ffDefault, select#fwDefault {
 	width: 120px;
 }
 input.cornerRadius {
-	width: 20px;
+	width: 25px;
 }
-
+input.fsDefault{
+	width: 35px;
+}
 /*demoOptions*/
 #demo-options {
 	clear: both;


### PR DESCRIPTION
Currently, values in input fields are not all visible (e.g. colors with wide characters, such as #363636, negative left and top offset of drop shadow, and font-size). This should allow these to be visible always. Please double check though that these are not causing any issues with other things... Thank you :-)
