### PR TITLE
ThemeRoller: Adding ui-icon-blank class name (added in 1.10).

### DIFF
--- a/template/themeroller/comp_group_a.html
+++ b/template/themeroller/comp_group_a.html
@@ -63,6 +63,7 @@
 <h2 class="demoHeaders">Framework Icons (content color preview)</h2>
 <ul id="icons" class="ui-widget ui-helper-clearfix">
 
+<li class="ui-state-default ui-corner-all" title=".ui-icon-blank"><span class="ui-icon ui-icon-blank"></span></li>
 <li class="ui-state-default ui-corner-all" title=".ui-icon-carat-1-n"><span class="ui-icon ui-icon-carat-1-n"></span></li>
 <li class="ui-state-default ui-corner-all" title=".ui-icon-carat-1-ne"><span class="ui-icon ui-icon-carat-1-ne"></span></li>
 <li class="ui-state-default ui-corner-all" title=".ui-icon-carat-1-e"><span class="ui-icon ui-icon-carat-1-e"></span></li>


### PR DESCRIPTION
Sending this as a pull request because I'm not sure whether it makes sense to show a blank class name in ThemeRoller or not. Thoughts?
