### PR TITLE
Package: Update to latest grunt-contrib-jshint

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,7 +2,7 @@ var Cache, cacheCron, cacheCronTimeout, cacheExpiresTime, caches,
 	logger = require( "simple-log" ).init( "download.jqueryui.com" );
 
 cacheExpiresTime = 0;
-caches = [],
+caches = [];
 
 cacheCron = function() {
 	var currentTime = Date.now();

--- a/lib/packer.js
+++ b/lib/packer.js
@@ -11,7 +11,7 @@ var indexTemplate, themeImagesCache,
 	sqwish = require( "sqwish" ),
 	util = require( "./util" );
 
-indexTemplate = handlebars.compile( fs.readFileSync( __dirname + "/../template/zip/index.html", "utf8" ) ),
+indexTemplate = handlebars.compile( fs.readFileSync( __dirname + "/../template/zip/index.html", "utf8" ) );
 themeImagesCache = {};
 
 function stripThemeImport( src ) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt": "0.4.1",
     "grunt-check-modules": "0.2.0",
     "grunt-contrib-handlebars": "0.5.7",
-    "grunt-contrib-jshint": "0.2.0",
+    "grunt-contrib-jshint": "0.9.2",
     "grunt-contrib-uglify": "0.2.0",
     "handlebars": "1.0.12",
     "lzma": "1.2.1",


### PR DESCRIPTION
Fix to lint errors in cache and packer, both abusing the comma operator.
