### PR TITLE
jQuery UI Themes Packer: Remove basedir from manifest paths, with optional slash

### DIFF
--- a/lib/themes-packer.js
+++ b/lib/themes-packer.js
@@ -126,7 +126,7 @@ ThemesPacker.prototype = {
 					}).map(function( file ) {
 						var md5 = crypto.createHash( "md5" );
 						md5.update( file.data );
-						return file.path.split( "/" ).slice( 1 ).join( "/" ) + " " + md5.digest( "hex" );
+						return file.path.slice( basedir.length ).replace( /^\//, "" ) + " " + md5.digest( "hex" );
 					}).join( "\n" )
 				});
 				return callback();


### PR DESCRIPTION
This works when basedir is set to "" (empty string), where removing the
first segment actually destroys all paths. Tested with jQuery UI's release
script.

This also works with the default, tested using the build-packages grunt task.
