### PR TITLE
Improve grunt-prepare error handling, specify supported npm version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,7 +102,7 @@ grunt.initConfig({
 function log( callback, successMsg, errorMsg ) {
 	return function( error, result, code ) {
 		if ( error && errorMsg ) {
-			grunt.log.error( errorMsg + ": " + error.stderr );
+			grunt.log.error( errorMsg + ": " + error );
 		} else if ( ! error && successMsg ) {
 			grunt.log.ok( successMsg );
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "download.jqueryui.com",
   "version": "2.0.21",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/jquery/download.jqueryui.com.git"
+  },
   "dependencies": {
     "archiver": "0.4.1",
     "async": "0.1.22",
@@ -33,9 +37,11 @@
     "nodeunit": "0.7.4"
   },
   "main": "main.js",
-  "engine": {
-    "node": ">=0.8.x"
+  "engines": {
+    "node": ">=0.8.x",
+    "npm": "<2.0.0"
   },
+  "engineStrict": true,
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
Fixes #238

As discussed on the issue, this works with npm <2.0.0, so for now we have to use that. I suggest we create a follow-up ticket, when merging this, to remove the `engines/npm` and `engineStrict` properties once we drop support for UI 1.10.