### PR TITLE
Gruntfile: Fix the need for manual npm install before prepare

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -279,7 +279,7 @@ function install( jqueryUi ) {
 					opts: {
 						cwd: "tmp/jquery-ui"
 					}
-				}, log( jqueryUi.docs ? next : callback, "Installed npm modules", "Error installing npm modules" ) );
+				}, log( jqueryUi.docs ? callback : next, "Installed npm modules", "Error installing npm modules" ) );
 			},
 			function( next ) {
 				grunt.log.writeln( "Installing api.jqueryui.com npm modules" );


### PR DESCRIPTION
The ```callback``` and ```next``` arguments placed in the wrong order, so ```npm install``` doesn't get run in ```tmp/api.jquery.com``` most of the time. 

This fixes the previous issue I had [here](https://github.com/jquery/jqueryui.com/issues/102) as well. 