### PR TITLE
Config: Add in docs property for 1.11.3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -308,19 +308,24 @@ function prepare( jqueryUi ) {
 	return function( callback ) {
 		async.series([
 			function() {
-				grunt.log.writeln( "Building API documentation for jQuery UI" );
-				if ( !fs.existsSync( "tmp/api.jqueryui.com/config.json" ) ) {
-					grunt.file.copy( "tmp/api.jqueryui.com/config-sample.json", "tmp/api.jqueryui.com/config.json" );
-					grunt.log.writeln( "Copied config-sample.json to config.json" );
-				}
-				rimraf.sync( "tmp/api.jqueryui.com/dist" );
-				grunt.util.spawn({
-					cmd: "grunt",
-					args: [ "build" ],
-					opts: {
-						cwd: "tmp/api.jqueryui.com"
+				if ( jqueryUi.docs === undefined ) {
+					grunt.log.writeln("API documentation not embedded from 1.11 onwards.");
+					callback();
+				} else {
+					grunt.log.writeln( "Building API documentation for jQuery UI" );
+					if ( !fs.existsSync( "tmp/api.jqueryui.com/config.json" ) ) {
+						grunt.file.copy( "tmp/api.jqueryui.com/config-sample.json", "tmp/api.jqueryui.com/config.json" );
+						grunt.log.writeln( "Copied config-sample.json to config.json" );
 					}
-				}, log( callback, "Done building documentation", "Error building documentation" ) );
+					rimraf.sync( "tmp/api.jqueryui.com/dist" );
+					grunt.util.spawn({
+						cmd: "grunt",
+						args: [ "build" ],
+						opts: {
+							cwd: "tmp/api.jqueryui.com"
+						}
+					}, log( callback, "Done building documentation", "Error building documentation" ) );
+				}
 			}
 		]);
 	};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -308,24 +308,22 @@ function prepare( jqueryUi ) {
 	return function( callback ) {
 		async.series([
 			function() {
-				if ( jqueryUi.docs === undefined ) {
-					grunt.log.writeln("API documentation not embedded from 1.11 onwards.");
-					callback();
-				} else {
-					grunt.log.writeln( "Building API documentation for jQuery UI" );
-					if ( !fs.existsSync( "tmp/api.jqueryui.com/config.json" ) ) {
-						grunt.file.copy( "tmp/api.jqueryui.com/config-sample.json", "tmp/api.jqueryui.com/config.json" );
-						grunt.log.writeln( "Copied config-sample.json to config.json" );
-					}
-					rimraf.sync( "tmp/api.jqueryui.com/dist" );
-					grunt.util.spawn({
-						cmd: "grunt",
-						args: [ "build" ],
-						opts: {
-							cwd: "tmp/api.jqueryui.com"
-						}
-					}, log( callback, "Done building documentation", "Error building documentation" ) );
+				if ( !jqueryUi.docs ) {
+					return callback();
 				}
+				grunt.log.writeln( "Building API documentation for jQuery UI" );
+				if ( !fs.existsSync( "tmp/api.jqueryui.com/config.json" ) ) {
+					grunt.file.copy( "tmp/api.jqueryui.com/config-sample.json", "tmp/api.jqueryui.com/config.json" );
+					grunt.log.writeln( "Copied config-sample.json to config.json" );
+				}
+				rimraf.sync( "tmp/api.jqueryui.com/dist" );
+				grunt.util.spawn({
+					cmd: "grunt",
+					args: [ "build" ],
+					opts: {
+						cwd: "tmp/api.jqueryui.com"
+					}
+				}, log( callback, "Done building documentation", "Error building documentation" ) );
 			}
 		]);
 	};

--- a/config.json
+++ b/config.json
@@ -4,7 +4,6 @@
 			"version": "1.11.3",
 			"dependsOn": "jQuery1.6+",
 			"label": "Stable",
-			"docs": true,
 			"stable": true
 		},
 		{

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
 			"version": "1.11.3",
 			"dependsOn": "jQuery1.6+",
 			"label": "Stable",
+			"docs": true,
 			"stable": true
 		},
 		{


### PR DESCRIPTION
This was preventing `grunt prepare` from running.

After looking through the code again from [this](https://github.com/jquery/download.jqueryui.com/pull/263), the if-else loop appears to be correct. My mistake on that. But the ```config.json``` file seems to require a ```doc``` property in order for the if-else loop to be executed correctly. 

If not ```npm install``` wouldn't run for ```tmp/api.jquery.com```. Do let me know if there are any mistakes with this! 

Fixes issue [262](https://github.com/jquery/download.jqueryui.com/issues/262) and also [this](https://github.com/jquery/jqueryui.com/issues/102).

Thanks!