### PR TITLE
Package: Include structure CSS in themes zip

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -382,10 +382,9 @@ function packagerZip(packageModule, zipBasedir, themeVars, folder, jqueryUi, cal
 	}
 	var target = fs.createWriteStream( filename );
 	var packager = new Packager( jqueryUi.files().cache, Package, {
-		// components + theme OR all themes (don't include components for theme package)
-		components: themeVars ? jqueryUi.components().map( function( component ) {
+		components: jqueryUi.components().map( function( component ) {
 			return component.name;
-		} ) : [],
+		} ),
 		jqueryUi: jqueryUi,
 		themeVars: themeVars
 	} );

--- a/lib/package-1-12-themes.js
+++ b/lib/package-1-12-themes.js
@@ -21,7 +21,20 @@ function Package( files, runtime ) {
 	Package1_12.apply( this, arguments );
 }
 
-extend( Package.prototype, Package1_12.prototype );
+// Copy some properties from the Package1_12's prototype
+[
+	"AUTHORS.txt",
+	"LICENSE.txt",
+	"images"
+].concat(
+	Object.keys(Package1_12.prototype)
+		.filter( function( property ) {
+			return /\.css$/.test( property );
+		} )
+).forEach( function( prop ) {
+	Package.prototype[ prop ] = Package1_12.prototype[ prop ];
+});
+
 extend( Package.prototype, {
 	"themes": function( callback ) {
 		var files = {};

--- a/lib/package-1-12-themes.js
+++ b/lib/package-1-12-themes.js
@@ -21,21 +21,17 @@ function Package( files, runtime ) {
 	Package1_12.apply( this, arguments );
 }
 
-// Copy some properties from the Package1_12's prototype
-[
-	"AUTHORS.txt",
-	"LICENSE.txt",
-	"images"
-].concat(
-	Object.keys(Package1_12.prototype)
-		.filter( function( property ) {
-			return /\.css$/.test( property );
-		} )
-).forEach( function( prop ) {
-	Package.prototype[ prop ] = Package1_12.prototype[ prop ];
-});
-
 extend( Package.prototype, {
+	"AUTHORS.txt": Package1_12.prototype[ "AUTHORS.txt" ],
+	"LICENSE.txt": Package1_12.prototype[ "LICENSE.txt" ],
+	"images": Package1_12.prototype[ "images" ],
+	"jquery-ui.css": Package1_12.prototype[ "jquery-ui.css" ],
+	"jquery-ui.structure.css": Package1_12.prototype[ "jquery-ui.structure.css" ],
+	"jquery-ui.theme.css": Package1_12.prototype[ "jquery-ui.theme.css" ],
+	"jquery-ui.min.css": Package1_12.prototype[ "jquery-ui.min.css" ],
+	"jquery-ui.structure.min.css": Package1_12.prototype[ "jquery-ui.structure.min.css" ],
+	"jquery-ui.theme.min.css": Package1_12.prototype[ "jquery-ui.theme.min.css" ],
+
 	"themes": function( callback ) {
 		var files = {};
 		var structureCssFileNames = this.structureCssFileNames;


### PR DESCRIPTION
Changes the 1.12 themes packager to be built on top of the 1.12 packager.

Fixes gh-298