### PR TITLE
Fix UglifyJS usage

### DIFF
--- a/lib/package-1-12.js
+++ b/lib/package-1-12.js
@@ -275,7 +275,7 @@ extend( Package.prototype, {
 
 		this.jsBundle.promise.then(function( js ) {
 			var _banner = banner( pkgJson, jsFileNames, { minify: true } ),
-				minJs = UglifyJS.minify( js, { fromString: true } ).code;
+				minJs = UglifyJS.minify( js ).code;
 			callback( null, _banner + minJs );
 		}).catch( callback );
 	},


### PR DESCRIPTION
The `fromString` option is no longer recognized; its usage was making the
library not return minified JS, resulting in `undefined` in the final code.