### PR TITLE
Fix globbing patterns used for jQuery UI 1.12 files list generation

### DIFF
--- a/lib/jquery-ui-files-1-12.js
+++ b/lib/jquery-ui-files-1-12.js
@@ -16,8 +16,8 @@ function JqueryUiFiles_1_12_0( jqueryUi ) {
 	readFile = this.readFile;
 	stripJqueryUiPath = this.stripJqueryUiPath;
 
-	glob( jqueryUi.path + "!(node_modules|build)" ).filter( noDirectory ).map( stripJqueryUiPath ).map( readFile );
-	glob( jqueryUi.path + "!(node_modules|build)/**" ).filter( noDirectory ).map( stripJqueryUiPath ).map( readFile );
+	glob( jqueryUi.path + "!(.*|node_modules|build)" ).filter( noDirectory ).map( stripJqueryUiPath ).map( readFile );
+	glob( jqueryUi.path + "!(.*|node_modules|build)/**" ).filter( noDirectory ).map( stripJqueryUiPath ).map( readFile );
 
 	this.componentFiles = Files( glob( jqueryUi.path + "ui/**/*.js" ).map( stripJqueryUiPath ).map( readFile ) );
 


### PR DESCRIPTION
`fast-glob` to which we switched from `glob` doesn't seem to exclude dotfiles
in a path segment matched by an exclusion; explicitly exclude dotfiles in the
pattern to account for that. Without this fix, directories like `.git` would
end up in the zip file generated for CDN purposes.