### PR TITLE
Package: Don't strip "use strict" pragmas from 1.13, improve formatting

### DIFF
--- a/lib/package-1-13.js
+++ b/lib/package-1-13.js
@@ -29,7 +29,7 @@ jsBundleIntro = "( function( factory ) {\n" +
 	"		// Browser globals\n" +
 	"		factory( jQuery );\n" +
 	"	}\n" +
-	"} )( function( $ ) {" +
+	"} )( function( $ ) {\n" +
 	"	\"use strict\";";
 
 jsBundleOutro = "} );";
@@ -149,13 +149,14 @@ extend( Package.prototype, {
 				return contents
 
 					// Remove UMD wrappers of UI & jQuery Color.
-					.replace( /\( ?function\( ?(?:root, ?)?factory\b[\s\S]*?\( ?(?:this, ?)?function\( ?[^\)]* ?\) ?\{/, "" )
+					.replace( /\( ?function\( ?(?:root, ?)?factory\b[\s\S]*?\( ?(?:this, ?)?function\( ?[^\)]* ?\) ?\{(?:\s*"use strict";\n)?/, "" )
 					.replace( /\} ?\);\s*?$/, "" )
 
 					// Replace return exports for var =.
 					.replace( /\nreturn/, "\nvar " + name + " =" );
 			},
 			optimize: "none",
+			useStrict: true,
 			paths: {
 				jquery: "../external/jquery/jquery"
 			},


### PR DESCRIPTION
Changes:
* Fix formatting of one of the outer `"use strict"` pragmas
* String `"use strict"` pragmas from individual unwrapped modules as those
pragmas only make sense at the beginning of a function wrapper we're removing
* Instruct RequireJS to not remove `"use strict"` pragmas from compiled code.

This will make jQuery UI 1.13 use strict mode both for modules and for the built
files.