### PR TITLE
Build: Remove unused tap-diff, test on Node 22, update actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,22 +9,22 @@ jobs:
       fail-fast: false
       matrix:
         # Node.js 18 is required by jQuery infra
-        NODE_VERSION: [18.x, 20.x]
+        NODE_VERSION: [18.x, 20.x, 22.x]
     steps:
     - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Install xsltproc
       run: |
         sudo apt-get install xsltproc
 
     - name: Use Node.js ${{ matrix.NODE_VERSION }}
-      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
       with:
         node-version: ${{ matrix.NODE_VERSION }}
 
     - name: Cache
-      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-npm-lock-${{ hashFiles('**/package-lock.json') }}
@@ -33,7 +33,7 @@ jobs:
           ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-
           ${{ runner.os }}-node-
           ${{ runner.os }}-
-    
+
 
     - name: Install dependencies
       run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
 				"qunit": "2.21.0",
 				"semver": "7.6.3",
 				"sqwish": "0.2.2",
-				"tap-diff": "0.1.1",
 				"uglify-js": "3.19.0",
 				"winston": "3.13.1",
 				"wolfy87-eventemitter": "5.2.9"
@@ -948,14 +947,6 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/diff": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-			"integrity": "sha512-9wfm3RLzMp/PyTFWuw9liEzdlxsdGixCW0ZTU1XDmtlAkvpVXTPGF8KnfSs0hm3BPbg19OrUPPsRkHXoREpP1g==",
-			"engines": {
-				"node": ">=0.3.1"
-			}
-		},
 		"node_modules/duplexer": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -1352,11 +1343,6 @@
 			"engines": {
 				"node": ">=0.8.x"
 			}
-		},
-		"node_modules/events-to-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-			"integrity": "sha512-inRWzRY7nG+aXZxBzEqYKB3HPgwflZRopAjDCHv0whhRx+MTUr1ei0ICZUypdyE0HRm4L2d5VEcIqLD6yl+BFA=="
 		},
 		"node_modules/exit": {
 			"version": "0.1.2",
@@ -2590,17 +2576,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-finite": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3185,14 +3160,6 @@
 			"resolved": "https://registry.npmjs.org/nsdeclare/-/nsdeclare-0.1.0.tgz",
 			"integrity": "sha512-Wb+BpXFfacpp1cgrQoO5Q2wKHACuMlUE6uayGFFLF3yVuXejBp5Rflk991hWvTQbUuQslXTIvBNOHqYTvzBSjA=="
 		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/object-inspect": {
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
@@ -3367,14 +3334,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/parse-ms": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-			"integrity": "sha512-LpH1Cf5EYuVjkBvCDBYvkUPh+iv2bk3FHflxHkpCYT0/FZ1d3N3uJaLiHr4yGuMcFUhv6eAivitTvWZI4B/chg==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -3483,14 +3442,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/plur": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
-			"integrity": "sha512-qSnKBSZeDY8ApxwhfVIwKwF36KVJqb1/9nzYYq3j3vdwocULCXT8f8fQGkiw1Nk9BGfxiDagEe/pwakA+bOBqw==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3508,19 +3459,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/pretty-ms": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
-			"integrity": "sha512-H2enpsxzDhuzRl3zeSQpQMirn8dB0Z/gxW96j06tMfTviUWvX14gjKb7qd1gtkUyYhDPuoNe00K5PqNvy2oQNg==",
-			"dependencies": {
-				"is-finite": "^1.0.1",
-				"parse-ms": "^1.0.0",
-				"plur": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/process": {
@@ -4181,81 +4119,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/tap-diff": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/tap-diff/-/tap-diff-0.1.1.tgz",
-			"integrity": "sha512-/CVa3F1UPQh9sZQqkyMPa1zggv0sT6IepS/WJjAlljJp9fy9xVgCEREllKdy7rrJTG8StKxXhdE3lbyyhCJC8Q==",
-			"dependencies": {
-				"chalk": "^1.1.1",
-				"diff": "^2.2.1",
-				"duplexer": "^0.1.1",
-				"figures": "^1.4.0",
-				"pretty-ms": "^2.1.0",
-				"tap-parser": "^1.2.2",
-				"through2": "^2.0.0"
-			},
-			"bin": {
-				"tap-diff": "distributions/cli.js"
-			}
-		},
-		"node_modules/tap-diff/node_modules/figures": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-			"integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
-			"dependencies": {
-				"escape-string-regexp": "^1.0.5",
-				"object-assign": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/tap-parser": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-1.3.2.tgz",
-			"integrity": "sha512-DvP7UJFCyqFPVTWrX51mqQPHAA7vvm77bUsIGGtaLSpHVVvfP6c4Xej5ymt0dVLngE5NouPwCsDzOVW9Bnobuw==",
-			"dependencies": {
-				"events-to-array": "^1.0.1",
-				"inherits": "~2.0.1",
-				"js-yaml": "^3.2.7"
-			},
-			"bin": {
-				"tap-parser": "bin/cmd.js"
-			},
-			"optionalDependencies": {
-				"readable-stream": "^2"
-			}
-		},
-		"node_modules/tap-parser/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"optional": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/tap-parser/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"optional": true
-		},
-		"node_modules/tap-parser/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"optional": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"node_modules/tar-stream": {
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
@@ -4283,42 +4146,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
-		},
-		"node_modules/through2": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-			"dependencies": {
-				"readable-stream": "~2.3.6",
-				"xtend": "~4.0.1"
-			}
-		},
-		"node_modules/through2/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/through2/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
-		"node_modules/through2/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
 		},
 		"node_modules/tiny-glob": {
 			"version": "0.2.9",
@@ -4700,14 +4527,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"engines": {
-				"node": ">=0.4"
-			}
 		},
 		"node_modules/yallist": {
 			"version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"qunit": "2.21.0",
 		"semver": "7.6.3",
 		"sqwish": "0.2.2",
-		"tap-diff": "0.1.1",
 		"uglify-js": "3.19.0",
 		"winston": "3.13.1",
 		"wolfy87-eventemitter": "5.2.9"


### PR DESCRIPTION
`tap-diff` was temporarily added before the decision to avoid modifying QUnit
output and I forgot to remove it.

Also, add testing on Node 22. It was broken in `22.5.0` due to a bug fixed
upstream in `22.5.1`.

In addition, update GitHub Actions.