### PR TITLE
Build: Run `apt-get update` before installing packages

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,9 +18,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+    - name: Update apt-get cache
+      run: sudo apt-get update
+
     - name: Install xsltproc
-      run: |
-        sudo apt-get install xsltproc
+      run: sudo apt-get install -y xsltproc
 
     # When Ubuntu Plucky is available in GitHub Actions, switch to it, remove
     # the following section and just install the `imagemagick` package normally


### PR DESCRIPTION
An out of date state of some runners makes `apt-get install` fail unless an `apt-get update` is scheduled first.